### PR TITLE
Dice database commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ See GRAF's [command documentation](https://gawdl3y.github.io/discord-graf/manual
 | roll             | Rolls specified dice. (Uses [dice-expression-evaluator](https://github.com/dbkang/dice-expression-evaluator)) |
 | maxroll          | Calculates the maximum possible roll for a dice expression.                                                   |
 | minroll          | Calculates the minimum possible roll for a dice expression.                                                   |
+| viewroll         | Views a roll's expression.                                                                                    |
+| rolls            | Lists/searches rolls in the database.                                                                         |
+| addroll          | Adds a roll to the database, or updates the existing one.                                                     |
+| deleteroll       | Deletes a roll from the database.                                                                             |
 | character        | Views a character's information.                                                                              |
 | characters       | Lists/searches characters in the database.                                                                    |
 | addcharacter     | Adds a character to the database, or updates the existing one.                                                |

--- a/migrations/001-initial-schema.sql
+++ b/migrations/001-initial-schema.sql
@@ -1,6 +1,8 @@
 -- Up
 CREATE TABLE characters (server_id INTEGER NOT NULL, name TEXT NOT NULL COLLATE NOCASE, info TEXT, user_id INTEGER NOT NULL);
 CREATE INDEX characters_index ON characters (server_id, name);
+CREATE TABLE rolls (server_id INTEGER NOT NULL, name TEXT NOT NULL COLLATE NOCASE, expression TEXT, user_id INTEGER NOT NULL);
+CREATE INDEX rolls_index ON rolls (server_id, name);
 /*CREATE TABLE mod_roles (server_id INTEGER NOT NULL, role_id INTEGER NOT NULL);
 CREATE INDEX mod_roles_index ON mod_roles (server_id, role_id);
 CREATE TABLE settings (server_id INTEGER, key TEXT NOT NULL, value TEXT);
@@ -9,6 +11,8 @@ CREATE INDEX settings_index ON settings (server_id, key);*/
 -- Down
 DROP TABLE characters;
 DROP INDEX characters_index;
+DROP TABLE rolls;
+DROP INDEX rolls_index;
 /*DROP TABLE mod_roles;
 DROP INDEX mod_roles_index;
 DROP TABLE settings;

--- a/src/commands/characters/view.js
+++ b/src/commands/characters/view.js
@@ -3,6 +3,7 @@
 
 import { Command, CommandFormatError } from 'discord-graf';
 import Character from '../../database/character';
+import * as transformers from '../../util/transformers';
 
 export default class ViewCharacterCommand extends Command {
 	constructor(bot) {
@@ -23,21 +24,7 @@ export default class ViewCharacterCommand extends Command {
 		if(!args[0]) throw new CommandFormatError(this, message.guild);
 		const characters = await Character.findInGuild(message.guild, args[0]);
 		if(characters.length === 1) {
-			let ownerName;
-			try {
-				const owner = await message.client.fetchUser(characters[0].owner);
-				ownerName = `${owner.username}#${owner.discriminator}`;
-				try {
-					const member = await message.guild.fetchMember(owner);
-					if(member.nickname) ownerName = `${member.nickname} (${ownerName})`;
-				} catch(err2) {
-					// do nothing
-				}
-				ownerName = this.bot.util.escapeMarkdown(ownerName);
-			} catch(err) {
-				ownerName = 'Unknown';
-			}
-
+			const ownerName = await transformers.ownerIdToName(message, characters[0].owner);
 			return `Character **${characters[0].name}** (created by ${ownerName}):\n${characters[0].info}`;
 		} else if(characters.length > 1) {
 			return this.bot.util.disambiguation(characters, 'characters');

--- a/src/commands/dice/add.js
+++ b/src/commands/dice/add.js
@@ -1,0 +1,48 @@
+'use babel';
+'use strict';
+
+import { Command, CommandFormatError } from 'discord-graf';
+import { oneLine } from 'common-tags';
+import Roll from '../../database/roll';
+
+export default class AddRollCommand extends Command {
+	constructor(bot) {
+		super(bot, {
+			name: 'add-roll',
+			aliases: ['save-roll'],
+			module: 'rolls',
+			memberName: 'add',
+			description: 'Adds a roll to the database, or updates the existing one.',
+			usage: 'add-roll <name> <expression>',
+			details: oneLine`
+				The roll name can be a maximum of 60 characters long, and must be surrounded by quotes if it contains spaces.
+				The expression must be a valid dice expression.
+				Only the owner of the roll and administrators/moderators may update it.
+			`,
+			examples: ['add-roll Percent 1d100', 'add-roll "Coin flip" 1d2'],
+			guildOnly: false,
+			argsType: 'multiple',
+			argsCount: 2,
+			argsSingleQuotes: false
+		});
+	}
+
+	async run(message, args) {
+		const name = args[0], expression = args[1];
+		if(!name || !expression) throw new CommandFormatError(this, message.guild);
+		if(this.bot.util.patterns.anyUserMentions.test(name)
+			|| this.bot.util.patterns.anyUserMentions.test(expression)) return 'Please do not use mentions in your roll name or expression.';
+
+		// Apply some restrictions
+		if(name.length > 60) return 'A roll\'s name may not be longer than 60 characters.';
+		if(name.includes('\n')) return 'A roll\'s name may not have multiple lines.';
+
+		// Add or update the roll
+		const result = await Roll.save(new Roll(message.guild, message.author, name, expression.replace(/(?:\s*\n\s*){3,}/g, '\n\n')));
+		if(result) {
+			return `${result.new ? 'Added' : 'Updated'} roll "${name}".`;
+		} else {
+			return `Unable to update roll "${name}". You are not the owner.`;
+		}
+	}
+}

--- a/src/commands/dice/clear.js
+++ b/src/commands/dice/clear.js
@@ -1,0 +1,43 @@
+'use babel';
+'use strict';
+
+import { Command } from 'discord-graf';
+import Roll from '../../database/roll';
+
+export default class ClearRollsCommand extends Command {
+	constructor(bot) {
+		super(bot, {
+			name: 'clear-rolls',
+			module: 'rolls',
+			memberName: 'clear',
+			description: 'Clears the rolls database.',
+			details: 'Only administrators may use this command.',
+			guildOnly: true
+		});
+
+		this.lastUser = null;
+		this.timeout = null;
+	}
+
+	hasPermission(guild, user) {
+		return this.bot.permissions.isAdmin(guild, user);
+	}
+
+	async run(message, args) {
+		if(this.lastUser && message.author.id === this.lastUser.id && args[0] && args[0].toLowerCase() === 'confirm') {
+			Roll.clearGuild(message.guild);
+			clearTimeout(this.timeout);
+			this.lastUser = null;
+			this.timeout = null;
+			return 'Cleared the roll database.';
+		} else {
+			if(this.timeout) {
+				clearTimeout(this.timeout);
+				this.timeout = null;
+			}
+			this.lastUser = message.author;
+			this.timeout = setTimeout(() => { this.lastUser = null; }, 30000);
+			return `Are you sure you want to delete all rolls? This cannot be undone. Use ${this.bot.util.usage('clear-rolls confirm', message.guild)} to continue.`;
+		}
+	}
+}

--- a/src/commands/dice/delete.js
+++ b/src/commands/dice/delete.js
@@ -1,0 +1,49 @@
+'use babel';
+'use strict';
+
+import { Command, CommandFormatError } from 'discord-graf';
+import { oneLine } from 'common-tags';
+import Roll from '../../database/roll';
+import * as transformers from '../../util/transformers';
+
+export default class DeleteRollCommand extends Command {
+	constructor(bot) {
+		super(bot, {
+			name: 'delete-roll',
+			aliases: ['remove-roll', 'del-roll', 'rm-roll'],
+			module: 'rolls',
+			memberName: 'delete',
+			description: 'Deletes a roll from the database.',
+			usage: 'delete-roll <name> [owner]',
+			details: oneLine`
+				The name can be the whole name of the roll, or just a part of it. Only the owner of the roll and administrators/moderators may delete it.
+				If there are multiple rolls with the same name but different owners, the owner name should be specified after the roll name.
+				If no owner is supplied, it will default to the current user.
+			`,
+			examples: ['delete-roll Percentage', 'delete-roll per', 'delete-roll Percentage user#1234'],
+			guildOnly: true,
+			argsType: 'multiple',
+			argsCount: 2
+		});
+	}
+
+	async run(message, args) {
+		if(!args[0]) throw new CommandFormatError(this, message.guild);
+
+		// Get roll owner ID, or default to the message author
+		const ownerId = args[1] ? transformers.ownerNameToId(message, args[1]) : message.author.id;
+		const rolls = await Roll.findInGuildForOwner(message.guild, ownerId, args[0]);
+
+		if(rolls.length === 1) {
+			if(await Roll.delete(rolls[0], message.author.id)) {
+				return `Deleted roll "${rolls[0].name}".`;
+			} else {
+				return `Unable to delete roll "${rolls[0].name}". You are not the owner.`;
+			}
+		} else if(rolls.length > 1) {
+			return `${this.bot.util.disambiguation(rolls, 'rolls')}\nUse ${this.bot.util.usage('view-roll <name> [owner]', message.guild)} to view information about a roll.`;
+		} else {
+			return `Unable to find roll. Use ${this.bot.util.usage('rolls', message.guild)} to view the list of rolls.`;
+		}
+	}
+}

--- a/src/commands/dice/list.js
+++ b/src/commands/dice/list.js
@@ -1,0 +1,52 @@
+'use babel';
+'use strict';
+
+import { Command } from 'discord-graf';
+import { stripIndents, oneLine } from 'common-tags';
+import Roll from '../../database/roll';
+import config from '../../config';
+import * as transformers from '../../util/transformers';
+
+export default class ListCharactersCommand extends Command {
+	constructor(bot) {
+		super(bot, {
+			name: 'rolls',
+			aliases: ['list-rolls'],
+			module: 'rolls',
+			memberName: 'list',
+			description: 'Lists/searches rolls in the database.',
+			usage: 'rolls [search] [page]',
+			details: oneLine`
+				If no search string is specified, all rolls will be listed.
+				If the search string is only one letter long, rolls that start with that roll will be listed.
+				If the search string is more than one letter, all rolls that contain that string will be listed.
+				If the search string contains spaces, it must be surrounded by quotes.
+			`,
+			examples: ['rolls', 'rolls p', 'rolls percent'],
+			guildOnly: true,
+			argsType: 'multiple'
+		});
+	}
+
+	async run(message, args) {
+		const last = args.length >= 1 ? args.length - 1 : 0;
+		const page = !isNaN(args[last]) ? parseInt(args.pop()) : 1;
+		const search = args.join(' ');
+		let rolls = await Roll.findInGuild(message.guild, search, false);
+		if(rolls.length > 0) {
+			// Add owner name to the Rolls to display alongside the Roll names
+			for(const [index, roll] of rolls.entries()) rolls[index].ownerName = await transformers.ownerIdToName(message, roll.owner);
+			rolls.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+			const paginated = this.bot.util.paginate(rolls, page, Math.floor(config.paginationItems));
+			rolls = paginated.items;
+			return stripIndents`
+				__**Roll${search ? `s ${search.length === 1 ? 'that begin with' : 'that contain'} "${search}"` : ' list'}, ${paginated.pageText}:**__
+				${rolls.map(roll => `**-** ${roll.name} (created by ${roll.ownerName})`).join('\n')}
+				${paginated.maxPage > 1 ? `\nUse ${this.bot.util.usage(`rolls ${search ? `${search} ` : ''}<page>`, message.guild)} to view a specific page.` : ''}
+				Use ${this.bot.util.usage('view-roll <name> [owner]', message.guild)} to view information about a roll.
+			`;
+		} else {
+			return `There are no rolls ${search ? `${search.length === 1 ? 'that begin with' : 'that contain'} "${search}"` : 'in the database'}.`;
+		}
+	}
+}

--- a/src/commands/dice/roll.js
+++ b/src/commands/dice/roll.js
@@ -4,6 +4,7 @@
 import { Command } from 'discord-graf';
 import DiceExpression from 'dice-expression-evaluator';
 import { oneLine } from 'common-tags';
+import Roll from '../../database/roll';
 
 const pattern = /^(.+?)(?:(>{1,2}|<{1,2})\s*([0-9]+?))?\s*$/;
 
@@ -15,13 +16,14 @@ export default class RollDiceCommand extends Command {
 			module: 'dice',
 			memberName: 'roll',
 			description: 'Rolls specified dice.',
-			usage: 'roll [dice expression]',
+			usage: 'roll [dice expression|name]',
 			details: oneLine`
 				Dice expressions can contain the standard representations of dice in text form (e.g. 2d20 is two 20-sided dice), with addition and subtraction allowed.
 				You may also use a single \`>\` or \`<\` symbol at the end of the expression to add a target for the total dice roll - for example, \`2d20 + d15 > 35\`.
 				You can count the number of successes using \`>>\` or \`<<\`, but only on a single dice expression - for example, \`4d30 >> 20\`.
 				When running the command with no dice expression, it will default to a D20.
 				When just a single plain number is provided, it will be interpreted as a single die with that many sides.
+				When an invalid dice expression is provided, the bot will search the database for a roll with that name saved by the callee and roll it if one is found.
 			`,
 			examples: ['roll 2d20', 'roll 3d20 - d10 + 6', 'roll d20 > 10', 'roll 6d20 >> 14', 'roll', 'roll 30', 'Billy McBillface attempts to slay the dragon. (Roll: d20 > 10)'],
 			patterns: [/\(\s*(?:roll|dice|rolldice|diceroll):\s*(.+?)(?:(>{1,2}|<{1,2})\s*([0-9]+?))?\s*\)/i]
@@ -41,60 +43,78 @@ export default class RollDiceCommand extends Command {
 			const matches = fromPattern ? args : pattern.exec(args[0]);
 			const dice = new DiceExpression(matches[1]);
 
-			// Restrict the maximum dice count
-			const totalDice = dice.dice.reduce((prev, die) => prev + (die.diceCount || 1), 0);
-			if(totalDice > 1000) return { plain: `${message.author} might hurt themselves by rolling that many dice at once!` };
-
-			// Roll the dice
-			const rollResult = dice.roll();
-			this.bot.logger.debug('Dice rolled.', { dice: dice.dice, result: rollResult, totalDice: totalDice });
-
-			if(matches[2]) {
-				// Deal with target operations
-				const target = parseInt(matches[3]);
-				let response;
-
-				// Target for total roll
-				if(matches[2] === '>' || matches[2] === '<') {
-					const success = matches[2] === '>' ? rollResult.roll > target : rollResult.roll < target;
-					const diceList = this.buildDiceList(rollResult, totalDice);
-					response = oneLine`
-						${message.author} has **${success ? 'succeeded' : 'failed'}**.
-						(Rolled ${rollResult.roll}, ${!success ? 'not' : ''} ${matches[2] === '>' ? 'greater' : 'less'} than ${target}${diceList ? `;   ${diceList}` : ''})
-					`;
-
-				// Target for individual dice (success counting)
-				} else if(matches[2] === '>>' || matches[2] === '<<') {
-					if(rollResult.diceRaw.length !== 1) return { plain: `${message.author} tried to count successes with multiple dice expressions.` };
-					const successes = rollResult.diceRaw[0].reduce((prev, die) => prev + (matches[2] === '>>' ? die > target : die < target), 0);
-					response = oneLine`
-						${message.author} has **${successes > 0 ? `succeeded ${successes} time${successes !== 1 ? 's' : ''}` : `failed`}**.
-						${rollResult.diceRaw[0].length > 1 ? `(${rollResult.diceRaw[0].join(',   ')})` : ''}
-					`;
-
-				// Oh dear.
-				} else {
-					throw new Error('Unknown target operator. This should not ever happen.');
-				}
-
-				return { plain: response, editable: false };
-			} else {
-				const diceList = this.buildDiceList(rollResult, totalDice);
-				return {
-					plain: `${message.author} rolled **${rollResult.roll}**.${diceList ? ` (${diceList})` : ''}`,
-					editable: false
-				};
-			}
+			return this.rollDice(dice, matches, message);
 		} catch(err) {
-			return { plain: `${message.author} specified an invalid dice expression.` };
+			// Expression was invalid, check for a saved roll before returning an error
+			try {
+				let alias = /\(roll:\s([a-zA-Z]*)\)/.exec(args[0]);
+				alias = alias ? alias[1] : args[0];
+				const rolls = await Roll.findInGuildForOwner(message.guild, message.author.id, alias);
+				const matches2 = pattern.exec(rolls[0].expression);
+				return this.rollDice(new DiceExpression(matches2[1]), matches2, message, alias);
+			} catch(err2) {
+				return { plain: `${message.author} specified an invalid dice expression and no saved roll was found with the given name.` };
+			}
 		}
 	}
 
 	buildDiceList(result, totalDice) {
 		let diceList = '';
 		if(totalDice <= 100 && (result.diceRaw.length > 1 || (result.diceRaw.length > 0 && result.diceRaw[0].length > 1))) {
-			diceList = result.diceRaw.map((res, i) => this.bot.util.nbsp(res.length > 1 ? `${res.join(' + ')} = ${result.diceSums[i]}` : res[0])).join(',   ');
+			diceList = result.diceRaw.map((res, i) => this.bot.util.nbsp(res.length > 1 ? `${res.join(' + ')} = ${result.diceSums[i]}` : res[0])).join(',	 ');
 		}
 		return diceList;
+	}
+
+	rollDice(dice, matches, message, rollName = '') {
+		// If a roll name was given by the database, display that in italics
+		rollName = rollName ? `_${rollName}_ ` : rollName;
+
+		// Restrict the maximum dice count
+		const totalDice = dice.dice.reduce((prev, die) => prev + (die.diceCount || 1), 0);
+		if(totalDice > 1000) return { plain: `${message.author} might hurt themselves by rolling that many dice at once!` };
+
+		// Roll the dice
+		const rollResult = dice.roll();
+		this.bot.logger.debug('Dice rolled.', { dice: dice.dice, result: rollResult, totalDice: totalDice });
+
+		let returnValue;
+		if(matches[2]) {
+			// Deal with target operations
+			const target = parseInt(matches[3]);
+			let response;
+
+			// Target for total roll
+			if(matches[2] === '>' || matches[2] === '<') {
+				const success = matches[2] === '>' ? rollResult.roll > target : rollResult.roll < target;
+				const diceList = this.buildDiceList(rollResult, totalDice);
+				response = oneLine`
+					${message.author} has **${success ? 'succeeded' : 'failed'}**.
+					(Rolled ${rollResult.roll}, ${!success ? 'not' : ''} ${matches[2] === '>' ? 'greater' : 'less'} than ${target}${diceList ? `;   ${diceList}` : ''})
+				`;
+
+			// Target for individual dice (success counting)
+			} else if(matches[2] === '>>' || matches[2] === '<<') {
+				if(rollResult.diceRaw.length !== 1) return { plain: `${message.author} tried to count successes with multiple dice expressions.` };
+				const successes = rollResult.diceRaw[0].reduce((prev, die) => prev + (matches[2] === '>>' ? die > target : die < target), 0);
+				response = oneLine`
+					${message.author} has **${successes > 0 ? `succeeded ${rollName} ${successes} time${successes !== 1 ? 's' : ''}` : `failed`}**.
+					${rollResult.diceRaw[0].length > 1 ? `(${rollResult.diceRaw[0].join(',   ')})` : ''}
+				`;
+
+			// Oh dear.
+			} else {
+				throw new Error('Unknown target operator. This should not ever happen.');
+			}
+
+			returnValue = { plain: response, editable: false };
+		} else {
+			const diceList = this.buildDiceList(rollResult, totalDice);
+			returnValue = {
+				plain: `${message.author} rolled ${rollName} **${rollResult.roll}**.${diceList ? ` (${diceList})` : ''}`,
+				editable: false
+			};
+		}
+		return returnValue;
 	}
 }

--- a/src/commands/dice/view.js
+++ b/src/commands/dice/view.js
@@ -1,0 +1,45 @@
+'use babel';
+'use strict';
+
+import { Command, CommandFormatError } from 'discord-graf';
+import { oneLine } from 'common-tags';
+import Roll from '../../database/roll';
+import * as transformers from '../../util/transformers';
+
+export default class ViewRollCommand extends Command {
+	constructor(bot) {
+		super(bot, {
+			name: 'view-roll',
+			aliases: ['show-roll'],
+			module: 'rolls',
+			memberName: 'view',
+			description: 'Views a roll\'s information.',
+			usage: 'roll <name> [owner]',
+			details: oneLine`
+				The name can be the whole name of the roll, or just a part of it.
+				If there are multiple rolls with the same name but different owners, the owner name should be specified after the roll name.
+			`,
+			examples: ['view-roll Percentage', 'view-roll per', 'view-roll Spot user#1234'],
+			guildOnly: true,
+			argsType: 'multiple',
+			argsCount: 2
+		});
+	}
+
+	async run(message, args) {
+		if(!args[0]) throw new CommandFormatError(this, message.guild);
+
+		// Get roll owner ID, or default to the message author
+		const ownerId = args[1] ? transformers.ownerNameToId(message, args[1]) : message.author.id;
+		const rolls = await Roll.findInGuildForOwner(message.guild, ownerId, args[0]);
+
+		if(rolls.length === 1) {
+			const ownerName = await transformers.ownerIdToName(message, rolls[0].owner);
+			return `Roll **${rolls[0].name}** (created by ${ownerName}):\n${rolls[0].expression}`;
+		} else if(rolls.length > 1) {
+			return `${this.bot.util.disambiguation(rolls, 'rolls')}\nUse ${this.bot.util.usage('view-roll <name> [owner]', message.guild)} to view information about a roll.`;
+		} else {
+			return `Unable to find roll. Use ${this.bot.util.usage('view-rolls', message.guild)} to view the list of rolls.`;
+		}
+	}
+}

--- a/src/database/roll.js
+++ b/src/database/roll.js
@@ -1,0 +1,126 @@
+'use babel';
+'use strict';
+
+import bot from '../bot';
+import db from './';
+
+const sqlFindByGuild = 'SELECT CAST(server_id AS TEXT) AS server_id, name, expression, CAST(user_id AS TEXT) AS user_id FROM rolls WHERE server_id = ?';
+const sqlFindByGuildAndNameAndOwner = 'SELECT CAST(server_id AS TEXT) AS server_id, name, expression, CAST(user_id AS TEXT) AS user_id FROM rolls WHERE server_id = ? AND name = ? AND user_id = ?';
+const sqlFindByGuildAndNameLike = 'SELECT CAST(server_id AS TEXT) AS server_id, name, expression, CAST(user_id AS TEXT) AS user_id FROM rolls WHERE server_id = ? AND name LIKE ?';
+const sqlFindByGuildAndNameLikeAndOwner = 'SELECT CAST(server_id AS TEXT) AS server_id, name, expression, CAST(user_id AS TEXT) AS user_id FROM rolls WHERE server_id = ? AND name LIKE ? AND user_id = ?';
+const sqlInsert = 'INSERT INTO rolls VALUES(?, ?, ?, ?)';
+const sqlUpdate = 'UPDATE rolls SET name = ?, expression = ? WHERE server_id = ? AND name = ?';
+const sqlDelete = 'DELETE FROM rolls WHERE server_id = ? AND name = ? AND user_id = ?';
+const sqlClear = 'DELETE FROM rolls WHERE server_id = ?';
+
+export default class Roll {
+	constructor(guild, owner, name, expression) {
+		if(!owner || !name) throw new Error('Roll name, owner, and guild must be specified.');
+		this.guild = (guild && guild.id) || guild || '';
+		this.owner = owner.id || owner;
+		this.name = name;
+		this.expression = expression;
+	}
+
+	static async save(roll) {
+		if(!roll) throw new Error('A roll must be specified.');
+		const findStmt = await db.prepare(sqlFindByGuildAndNameAndOwner);
+		const existingRolls = await findStmt.all(roll.guild, roll.name, roll.owner);
+		findStmt.finalize();
+		if(existingRolls.length > 1) throw new Error('Multiple existing rolls found.');
+		if(existingRolls.length === 1) {
+			if(existingRolls[0].user_id === roll.owner || bot.permissions.isMod(roll.guild, roll.owner)) {
+				const updateStmt = await db.prepare(sqlUpdate);
+				await updateStmt.run(roll.name, roll.expression, roll.guild, existingRolls[0].name);
+				updateStmt.finalize();
+				bot.logger.info('Updated existing roll.', roll);
+				return { roll: new Roll(roll.guild, existingRolls[0].user_id, roll.name, roll.expression), new: false };
+			} else {
+				return false;
+			}
+		} else {
+			const insertStmt = await db.prepare(sqlInsert);
+			await insertStmt.run(roll.guild, roll.name, roll.expression, roll.owner);
+			insertStmt.finalize();
+			bot.logger.info('Added new roll.', roll);
+			return { roll: roll, new: true };
+		}
+	}
+
+	// As Rolls are both Guild and User specific, we have to be passed the command caller to be able to check for Mod permissions correctly
+	static async delete(roll, caller) {
+		if(!roll) throw new Error('A roll must be specified.');
+		if(!caller) caller = roll.owner;
+		const findStmt = await db.prepare(sqlFindByGuildAndNameAndOwner);
+		const existingRolls = await findStmt.all(roll.guild, roll.name, roll.owner);
+		findStmt.finalize();
+		if(existingRolls.length > 1) throw new Error('Multiple existing rolls found.');
+		if(existingRolls.length === 1) {
+			if(existingRolls[0].user_id === caller || bot.permissions.isMod(roll.guild, caller)) {
+				const deleteStmt = await db.prepare(sqlDelete);
+				await deleteStmt.run(roll.guild, roll.name, roll.owner);
+				deleteStmt.finalize();
+				bot.logger.info('Deleted roll.', roll);
+				return true;
+			} else {
+				return false;
+			}
+		} else {
+			return false;
+		}
+	}
+
+	static async clearGuild(guild) {
+		if(!guild) throw new Error('A guild must be specified.');
+		const clearStmt = await db.prepare(sqlClear);
+		await clearStmt.run(guild.id);
+		clearStmt.finalize();
+		bot.logger.info('Cleared rolls.', { guild: guild.name, guildID: guild.id });
+	}
+
+	static async findInGuild(guild, searchString = null, searchExact = true) {
+		if(!guild) throw new Error('A guild must be specified.');
+		guild = guild.id ? guild.id : guild;
+		const findStmt = await db.prepare(searchString ? sqlFindByGuildAndNameLike : sqlFindByGuild);
+		const rolls = await findStmt.all(guild, searchString ? searchString.length > 1 ? `%${searchString}%` : `${searchString}%` : undefined);
+		findStmt.finalize();
+		for(const [index, roll] of rolls.entries()) rolls[index] = new Roll(roll.server_id, roll.user_id, roll.name, roll.expression);
+		return searchExact ? bot.util.search(rolls, searchString, { searchInexact: false }) : rolls;
+	}
+
+	static async findInGuildForOwner(guild, owner, searchString = null, searchExact = true) {
+		if(!guild) throw new Error('A guild must be specified.');
+		guild = guild.id ? guild.id : guild;
+		owner = owner.id ? owner.id : owner;
+		const findStmt = await db.prepare(searchString ? sqlFindByGuildAndNameLikeAndOwner : sqlFindByGuild);
+		const rolls = await findStmt.all(guild, searchString ? searchString.length > 1 ? `%${searchString}%` : `${searchString}%` : undefined, owner);
+		findStmt.finalize();
+		for(const [index, roll] of rolls.entries()) rolls[index] = new Roll(roll.server_id, roll.user_id, roll.name, roll.expression);
+		return searchExact ? bot.util.search(rolls, searchString, { searchInexact: false }) : rolls;
+	}
+
+	static async convertStorage() {
+		bot.logger.info('Converting storage for rolls');
+		const storageEntry = bot.localStorage.getItem('rolls');
+		if(!storageEntry) return;
+		const baseMap = JSON.parse(storageEntry);
+		if(!baseMap) return;
+		const keys = Object.keys(baseMap);
+		if(keys.length === 0) return;
+		const rolls = [];
+		for(const key of keys) {
+			const guildRolls = baseMap[key];
+			if(!guildRolls || guildRolls.length === 0) continue;
+			rolls.push(...guildRolls);
+		}
+		if(rolls.length > 0) {
+			const stmt = await db.prepare(sqlInsert);
+			for(const roll of rolls) {
+				stmt.run(roll.guild, roll.name, roll.expression, roll.owner);
+			}
+			stmt.finalize();
+		}
+		bot.localStorage.removeItem('rolls');
+		bot.logger.info('Converted rolls from local storage to database.', { count: rolls.length });
+	}
+}

--- a/src/rpbot.js
+++ b/src/rpbot.js
@@ -10,15 +10,22 @@ import * as db from './database';
 import Character from './database/character';
 import * as analytics from './util/analytics';
 import DiceExpression from 'dice-expression-evaluator';
+import Roll from './database/roll';
 
 import ListCharactersCommand from './commands/characters/list';
 import ViewCharacterCommand from './commands/characters/view';
 import AddCharacterCommand from './commands/characters/add';
 import DeleteCharacterCommand from './commands/characters/delete';
 import ClearCharactersCommand from './commands/characters/clear';
+
 import RollDiceCommand from './commands/dice/roll';
 import MaxRollCommand from './commands/dice/max';
 import MinRollCommand from './commands/dice/min';
+import AddRollCommand from './commands/dice/add';
+import ViewRollCommand from './commands/dice/view';
+import ListRollsCommand from './commands/dice/list';
+import DeleteRollCommand from './commands/dice/delete';
+import ClearRollsCommand from './commands/dice/clear';
 
 bot.logger.info(`RPBot v${version} is starting...`);
 analytics.sendEvent('Bot', 'started');
@@ -28,7 +35,8 @@ export const client = bot
 	.registerDefaults()
 	.registerModules([
 		['characters', 'Characters'],
-		['dice', 'Dice']
+		['dice', 'Dice'],
+		['rolls', 'Rolls']
 	])
 	.registerCommands([
 		ListCharactersCommand,
@@ -38,11 +46,17 @@ export const client = bot
 		ClearCharactersCommand,
 		RollDiceCommand,
 		MaxRollCommand,
-		MinRollCommand
+		MinRollCommand,
+		AddRollCommand,
+		ViewRollCommand,
+		ListRollsCommand,
+		DeleteRollCommand,
+		ClearRollsCommand
 	])
 	.registerEvalObjects({
 		db: db,
 		Character: Character,
+		Roll: Roll,
 		config: config,
 		version: version,
 		dice: DiceExpression

--- a/src/util/transformers.js
+++ b/src/util/transformers.js
@@ -1,0 +1,33 @@
+import bot from '../bot';
+
+export async function ownerIdToName(message, ownerId) {
+	let ownerName;
+	try {
+		const owner = await message.client.fetchUser(ownerId);
+		ownerName = `${owner.username}#${owner.discriminator}`;
+		try {
+			const member = await message.guild.fetchMember(owner);
+			if(member.nickname) ownerName = `${member.nickname} (${ownerName})`;
+		} catch(err2) {
+			// do nothing
+		}
+		ownerName = bot.util.escapeMarkdown(ownerName);
+	} catch(err) {
+		ownerName = 'Unknown';
+	}
+	return ownerName;
+}
+
+export function ownerNameToId(message, ownerName) {
+	if(bot.util.patterns.anyUserMentions.test(ownerName)) {
+		return /<@!?([0-9]*)>/.exec(ownerName)[1];
+	}
+
+	ownerName = ownerName.split('#');
+	try {
+		const owner = message.client.users.find((user) => user.username === ownerName[0] && user.discriminator === ownerName[1]);
+		return owner.id;
+	} catch(err) {
+		throw new Error('Unable to find a user with that username and discriminator combination.');
+	}
+}


### PR DESCRIPTION
Dice expressions can now be stored in the database in the same fashion as
Characters. (NB: database entities are 'Roll' to avoid the potentially
awkward singular version of 'dice' -> 'die' in some commands).
Roll names are not unique, but can be differentiated by the owner's name
and discriminator.
The roll command now also accepts Roll names, and will roll the saved
expression if one is present and has been created by the current user.

Changes:
- Create 'rolls' database table
- Create the following commands:
  - add-roll
  - delete-roll
  - view-roll
  - clear-rolls
- Update 'roll' command to accept a roll alias
- Create transformers util
- Update 'view-character' command to use transformers
  util
- Update README
